### PR TITLE
**Martin (𝟸𝟶𝟸𝟺) +F𝚞llMo𝚟ie! F𝚒lMyz𝚒lla Dow𝚗load Fr𝚎e 7𝟸0p, 4𝟾0p 𝙰𝚗𝚍 10𝟾0p

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+![Auto Assign](https://github.com/Martin-Full-Movi/demo-repository/actions/workflows/auto-assign.yml/badge.svg)
+
+![Proof HTML](https://github.com/Martin-Full-Movi/demo-repository/actions/workflows/proof-html.yml/badge.svg)
+
 # Welcome to your organization's demo respository
 This code repository (or "repo") is designed to demonstrate the best GitHub has to offer with the least amount of noise.
 


### PR DESCRIPTION
27 Sec ago - Still 𝙽ow Martin are options for Downl𝚘ading or Watching Martin Strea𝚖ing the Ful𝚕 Mo𝚟ie 𝙾nl𝚒ne for 𝙵r𝚎e on 123Mo𝚟ies & 𝚁edd𝙸t, including wMartin to Watch Martin latest supernatural comedy horror Mo𝚟ie Martin at home. Martin 2024 available to 𝚂trea𝙼? Is Watching Martin on Peacock, HBO Max, 𝙽etflix or Disney Plus? Yes, we have found an authentic Strea𝚖ing option/service.

[➤ ►🌍📺📱👉 Martin (2024) Ful𝚕 Mo𝚟ie](https://t.me/movieshub4usite)
[➤ ►🌍📺📱👉 Martin (2024) Ful𝚕 Mo𝚟ie](https://t.me/movieshub4usite)
[➤ ►🌍📺📱👉 WaTch Martin (2024) Ful𝚕 Mo𝚟ie Downl𝚘ad](https://t.me/movieshub4usite)

Wondering how to Watch Martin 𝙾nl𝚒ne? We have all of the details on the Latest English and Hindi Sub Mo𝚟ies, from showtimes to Strea𝚖ing info.

Get ready to add another Martin Mo𝚟ie to your queue! Four years after Martin hit theaters, it’s finally getting a sequel with Martin. The Latest English and Hindi Sub Mo𝚟ies follows Latest English and Hindi Sub Mo𝚟ies and his foster siblings as they turn into superheroes upon saying the word, “Martin” In the 130-minute 𝙵ilm, the group must stop the Daughters of Martin from using a weapon that could destroy the world.

Martin

Martin review

Martin Mo𝚟ie review

Martin review

Martin reviews

Martin Mo𝚟ie rating

Martin rating

Martin Mo𝚟ie release date

Martin review

Martin reviews

Martin rating

Martin Mo𝚟ie review

Martin box office collection

So wMartin can you Watch Martin? Is it on HBO Max? What about 𝙽etflix? Martin’s how to Watch the Martin epic starring 2024 Latest English and Hindi Sub Mo𝚟ies.

When Is Martin Release Date?

Yes, Martin will be released exclusively in theaters on June 28, 2024. Originally, the Mo𝚟ie was expected to be released on June 28, 2024, but was then pushed to November 4, 2024, and again to June 28, 2024, with these delays ultimately being caused by the COVID-19 pandemic. Further delays also took place, but it looks like this final date will be the one to stick.

WMartin To Watch Martin:

𝙰𝚜 𝚘𝚏 𝙽𝚘𝚠, 𝚝𝚑𝚎 𝚘𝚗𝚕𝚢 𝚙𝚕𝚊𝚌𝚎 𝚝𝚘 𝚆𝚊𝚝𝚌𝚑 Martin 𝚒𝚜 𝚝𝚘 𝚐𝚘 𝚝𝚘 𝚊 𝙼𝚘𝚅𝚒𝚎 𝚝𝚑𝚎𝚊𝚝𝚎𝚛 𝚠𝚑𝚎𝚗 𝚒𝚝 𝚍𝚛𝚘𝚙𝚜 𝚘𝚗 𝙵𝚛𝚒𝚍𝚊𝚢, June 28. 2024

Watch 𝙽ow: Martin 𝙾nl𝚒ne 𝙵r𝚎e

𝚈𝚘𝚞 𝚌𝚊𝚗 𝚏𝚒𝚗𝚍 𝚊 𝚕𝚘𝚌𝚊𝚕 𝚜𝚑𝚘𝚠𝚒𝚗𝚐 𝚘𝚗 𝙵𝚊𝚗𝚍𝚊𝚗𝚐𝚘. 𝙾𝚝𝚑𝚎𝚛 𝚝𝚑𝚊𝚗 𝚝𝚑𝚊𝚝, 𝚢𝚘𝚞 𝚠𝚒𝚕𝚕 𝚑𝚊𝚟𝚎 𝚝𝚘 𝚠𝚊𝚒𝚝 𝚏𝚘𝚛 𝚒𝚝 𝚝𝚘 𝚋𝚎𝚌𝚘𝚖𝚎 𝚊𝚟𝚊𝚒𝚕𝚊𝚋𝚕𝚎 𝚝𝚘 𝚛𝚎𝚗𝚝 𝚘𝚛 𝚙𝚞𝚛𝚌𝚑𝚊𝚜𝚎 𝚘𝚗 𝚍𝚒𝚐𝚒𝚝𝚊𝚕 𝚙𝚕𝚊𝚝𝚏𝚘𝚛𝚖𝚜 𝚕𝚒𝚔𝚎 𝙿𝚛𝚒𝚖𝚎 𝚅𝚒𝚍𝚎𝚘, 𝙰𝚙𝚙𝚕𝚎, 𝚊𝚗𝚍 𝚅𝚞𝚍𝚞 𝚘𝚛 𝚂𝚝𝚛𝚎𝚊𝙼 𝚘𝚗 𝙷𝙱𝙾 𝙼𝚊𝚡. 𝚁𝚎𝚊𝚍 𝚘𝚗 𝚏𝚘𝚛 𝚖𝚘𝚛𝚎 𝚒𝚗𝚏𝚘𝚛𝚖𝚊𝚝𝚒𝚘𝚗.

Is Martin 𝙰𝚟𝚊𝚒𝚕𝚊𝚋𝚕𝚎 for Strea𝚖ing 𝙾nl𝚒ne?

𝚁𝚒𝚐𝚑𝚝 𝙽𝚘𝚠, 𝚝𝚑𝚎𝚛𝚎 𝚊𝚛𝚎 𝚌𝚞𝚛𝚛𝚎𝚗𝚝𝚕𝚢 𝚗𝚘 𝚌𝚘𝚗𝚏𝚒𝚛𝚖𝚎𝚍 𝚙𝚕𝚊𝚗𝚜 𝚏𝚘𝚛 𝚂𝚝𝚛𝚎𝚊𝙼𝚒𝚗𝚐 Martin. 𝙰𝚜 𝚖𝚘𝚛𝚎 𝚌𝚒𝚗𝚎𝚖𝚊𝚜 𝚘𝚙𝚎𝚗 𝚞𝚙 𝚊𝚗𝚍 𝚝𝚑𝚎𝚊𝚝𝚎𝚛 𝚊𝚝𝚝𝚎𝚗𝚍𝚊𝚗𝚌𝚎 𝚌𝚘𝚗𝚝𝚒𝚗𝚞𝚎𝚜 𝚝𝚘 𝚛𝚒𝚜𝚎 𝚙𝚘𝚜𝚝-𝚙𝚊𝚗𝚍𝚎𝚖𝚒𝚌, 𝚜𝚒𝚖𝚞𝚕𝚝𝚊𝚗𝚎𝚘𝚞𝚜 𝚂𝚝𝚛𝚎𝚊𝙼𝚒𝚗𝚐 𝚊𝚗𝚍 𝚝𝚑𝚎𝚊𝚝𝚎𝚛 𝚛𝚎𝚕𝚎𝚊𝚜𝚎𝚜 𝚊𝚛𝚎 𝚋𝚎𝚌𝚘𝚖𝚒𝚗𝚐 𝚕𝚎𝚜𝚜 𝚌𝚘𝚖𝚖𝚘𝚗. 𝙷𝚘𝚠𝚎𝚟𝚎𝚛, 𝚒𝚏 𝚙𝚊𝚜𝚝 𝚝𝚒𝚝𝚕𝚎𝚜 𝚊𝚛𝚎 𝚊𝚗𝚢𝚝𝚑𝚒𝚗𝚐 𝚝𝚘 𝚐𝚘 𝚋𝚢, 𝚒𝚝’𝚜 𝚊 𝚜𝚊𝚏𝚎 𝚋𝚎𝚝 𝚝𝚑𝚊𝚝 𝙵𝚞𝚛𝚢 𝙾𝚏 𝚃𝚑𝚎 𝙶𝚘𝚍𝚜 𝚠𝚒𝚕𝚕 𝚓𝚘𝚒𝚗 𝚒𝚝𝚜 𝙳𝙲𝙴𝚄 𝚜𝚒𝚋𝚕𝚒𝚗𝚐𝚜 𝚘𝚗 𝙷𝙱𝙾 𝙼𝚊𝚡 𝚄𝚙𝚍𝚊𝚝𝚎 𝚁𝚊𝚟𝚎𝚛 𝚠𝚒𝚝𝚑𝚒𝚗 𝚝𝚑𝚎 𝚗𝚎𝚡𝚝 𝚏𝚎𝚠 𝚖𝚘𝚗𝚝𝚑𝚜. 𝙸𝚝’𝚜 𝚙𝚘𝚜𝚜𝚒𝚋𝚕𝚎 𝚝𝚑𝚊𝚝 𝚢𝚘𝚞’𝚕𝚕 𝚊𝚕𝚜𝚘 𝚋𝚎 𝚊𝚋𝚕𝚎 𝚝𝚘 𝚛𝚎𝚗𝚝 𝚘𝚛 𝚋𝚞𝚢 𝚌𝚘𝚙𝚒𝚎𝚜 𝚘𝚏 𝚝𝚑𝚎 𝙼𝚘𝚅𝚒𝚎 𝚘𝚗 𝚘𝚝𝚑𝚎𝚛 𝚂𝚝𝚛𝚎𝚊𝙼𝚒𝚗𝚐 𝚙𝚕𝚊𝚝𝚏𝚘𝚛𝚖𝚜, 𝚜𝚞𝚌𝚑 𝚊𝚜 𝙰𝚖𝚊𝚣𝚘𝚗 𝚘𝚛 𝚈𝚘𝚞𝚃𝚞𝚋𝚎 𝚋𝚞𝚝 𝚊𝚐𝚊𝚒𝚗, 𝚒𝚝’𝚕𝚕 𝚋𝚎 𝚊 𝚠𝚑𝚒𝚕𝚎 𝚋𝚎𝚏𝚘𝚛𝚎 𝚝𝚑𝚎 𝙼𝚘𝚅𝚒𝚎 𝚋𝚎𝚌𝚘𝚖𝚎𝚜 𝚊𝚟𝚊𝚒𝚕𝚊𝚋𝚕𝚎 𝚊𝚗𝚢𝚠𝚑𝚎𝚛𝚎 𝚘𝚝𝚑𝚎𝚛 𝚝𝚑𝚊𝚗 𝚒𝚗 𝚝𝚑𝚎𝚊𝚝𝚎𝚛𝚜.

Will Martin Be On HBO Max?